### PR TITLE
Remove (hacky) asar build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
   "description": "A file sharing app using IPFS (InterPlanetary File System)",
   "main": "src/electron/main.js",
   "scripts": {
-    "build_electron": "yarn fix_asar && build",
+    "build_electron": "build",
     "build_ui": "webpack",
-    "fix_asar": "sed -i '' 's|run(cmd, args|run(cmd.replace(\"app.asar\", \"app.asar.unpacked\"), args|' node_modules/ipfsd-ctl/src/exec.js",
     "lint": "eslint --ext .js --ext .jsx --format=node_modules/eslint-formatter-pretty src/",
     "preversion": "yarn build_ui",
-    "release": "yarn build_ui && yarn fix_asar && build --draft",
+    "release": "yarn build_ui && build --draft",
     "run_electron": "ENV=dev electron src/electron/main.js",
     "start": "yarn watch & yarn run_electron",
     "watch": "webpack --progress --colors --watch"
@@ -54,6 +53,7 @@
   "build": {
     "appId": "partyshare.busterlabs.xyz",
     "artifactName": "${productName}.${ext}",
+    "asarUnpack": "node_modules/go-ipfs-dep",
     "productName": "Partyshare",
     "icon": "build_assets/partyshare.icns",
     "forceCodeSigning": true,


### PR DESCRIPTION
## What

A combination of two events allow us to remove this step

1. https://github.com/ipfs/js-ipfsd-ctl/commit/a44cb79eedebae6d6f5bf232279b73d5cbe4718b allows `ipfsd-ctl` to find the unpacked asar location
2. Declaring `go-ipfs-dep` to be unpacked in electron-builder

Closes #14 
Closes #40 