### PR TITLE
Kickstart travis builds with a simple lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - '8'
+
+cache: yarn
+
+script:
+  - yarn lint


### PR DESCRIPTION
Kicking the tires with travis for a potential build pipeline. To keep it simple, this just runs `eslint`.